### PR TITLE
fix: increase import filesize limit from 32KB to 1MB

### DIFF
--- a/src/app/page/main/ImportExport.vue
+++ b/src/app/page/main/ImportExport.vue
@@ -123,8 +123,8 @@ export default {
     },
     async impFile(event) {
       const [file] = event.target.files
-      // the biggest file size is 32KB & unrestricted file type
-      if (file.size > (1 << 15)) return
+      // the biggest file size is 1MB & unrestricted file type
+      if (file.size > (1 << 20)) return
       const text = await readFile(file)
       this.importData = text
     },


### PR DESCRIPTION
I believe that this will address https://github.com/cnwangjie/better-onetab/issues/132 for most users. I've tested this on my computer on Firefox with the following onetab exports (~1KB, ~250KB, ~750KB, respectively):

- https://gist.github.com/adamreis/e27fc2a953eaa318d8c24c054fa9ca42
- https://gist.github.com/adamreis/4db38221dc4f12f123334a9ea93ddaa2
- https://gist.github.com/adamreis/a431176e61c3462b1d318227c408585a

All work smoothly and have no noticeable latency. I've not tested on Chrome. 

Regardless of whether this is merged, there should probably be a visible error message if the file size limit is exceeded. I spent ~10 minutes trying to add this (with a `<v-alert>`), but couldn't figure out how to import that component (first time in a Vue codebase). @cnwangjie think this is worth adding as a small TODO on the roadmap?